### PR TITLE
feat(sec group): added configurable security group for secondary cluster

### DIFF
--- a/API.md
+++ b/API.md
@@ -91,7 +91,9 @@ addRegionalCluster(scope: Construct, id: string, options: RegionalOptions): void
 * **id** (<code>string</code>)  *No description*
 * **options** (<code>[RegionalOptions](#cdk-aurora-globaldatabase-regionaloptions)</code>)  *No description*
   * **region** (<code>string</code>)  *No description* 
+  * **dbClusterpPG** (<code>string</code>)  *No description* __*Optional*__
   * **dbSubnetGroupName** (<code>string</code>)  *No description* __*Optional*__
+  * **securityGroupId** (<code>string</code>)  *No description* __*Optional*__
 
 
 
@@ -184,7 +186,9 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **region**🔹 | <code>string</code> | <span></span>
+**dbClusterpPG**?🔹 | <code>string</code> | __*Optional*__
 **dbSubnetGroupName**?🔹 | <code>string</code> | __*Optional*__
+**securityGroupId**?🔹 | <code>string</code> | __*Optional*__
 
 
 

--- a/API.md
+++ b/API.md
@@ -91,7 +91,7 @@ addRegionalCluster(scope: Construct, id: string, options: RegionalOptions): void
 * **id** (<code>string</code>)  *No description*
 * **options** (<code>[RegionalOptions](#cdk-aurora-globaldatabase-regionaloptions)</code>)  *No description*
   * **region** (<code>string</code>)  *No description* 
-  * **dbClusterpPG** (<code>string</code>)  *No description* __*Optional*__
+  * **dbParameterGroup** (<code>string</code>)  *No description* __*Optional*__
   * **dbSubnetGroupName** (<code>string</code>)  *No description* __*Optional*__
   * **securityGroupId** (<code>string</code>)  *No description* __*Optional*__
 
@@ -186,7 +186,7 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **region**🔹 | <code>string</code> | <span></span>
-**dbClusterpPG**?🔹 | <code>string</code> | __*Optional*__
+**dbParameterGroup**?🔹 | <code>string</code> | __*Optional*__
 **dbSubnetGroupName**?🔹 | <code>string</code> | __*Optional*__
 **securityGroupId**?🔹 | <code>string</code> | __*Optional*__
 

--- a/custom-resource-handler/add_region_index.py
+++ b/custom-resource-handler/add_region_index.py
@@ -33,6 +33,7 @@ def on_create(event):
     InstanceType_value = props['InstanceType']
     rdsIsPublic_value = props['rdsIsPublic']
     seconddbInstanceIdentifier_value = props['seconddbInstanceIdentifier']
+    securityGroup_value = props['securityGroup']
     data ={
       'GlobalClusterIdentifier': GlobalClusterIdentifier_value,
       'SourceDBClusterIdentifier': SourceDBClusterIdentifier_value
@@ -43,7 +44,8 @@ def on_create(event):
         Engine=Engine_value,
         EngineVersion=EngineVersion_value,
         GlobalClusterIdentifier=GlobalClusterIdentifier_value,
-        DBSubnetGroupName=DBSubnetGroupName_value
+        DBSubnetGroupName=DBSubnetGroupName_value,
+        VpcSecurityGroupIds=[securityGroup_value],
     )
     data['secondRDSClusterArn'] = create_db_cluster_res['DBCluster']['DBClusterArn']
     time.sleep(5)
@@ -55,7 +57,6 @@ def on_create(event):
         Engine=Engine_value,
         PubliclyAccessible= str2bool(rdsIsPublic_value) or False
     )
-    data['seconddbInstanceIdentifier']=seconddbInstanceIdentifier_value
     if (data):
       output = {'Data': data}
     else:

--- a/custom-resource-handler/add_region_index.py
+++ b/custom-resource-handler/add_region_index.py
@@ -34,6 +34,7 @@ def on_create(event):
     rdsIsPublic_value = props['rdsIsPublic']
     seconddbInstanceIdentifier_value = props['seconddbInstanceIdentifier']
     securityGroup_value = props['securityGroup']
+    dbParameterGroup_value = props['dbParameterGroup']
     data ={
       'GlobalClusterIdentifier': GlobalClusterIdentifier_value,
       'SourceDBClusterIdentifier': SourceDBClusterIdentifier_value
@@ -46,6 +47,7 @@ def on_create(event):
         GlobalClusterIdentifier=GlobalClusterIdentifier_value,
         DBSubnetGroupName=DBSubnetGroupName_value,
         VpcSecurityGroupIds=[securityGroup_value],
+        DBClusterParameterGroupName=dbParameterGroup_value
     )
     data['secondRDSClusterArn'] = create_db_cluster_res['DBCluster']['DBClusterArn']
     time.sleep(5)

--- a/src/index.ts
+++ b/src/index.ts
@@ -518,7 +518,7 @@ export interface GlobalAuroraRDSMasterProps {
 export interface RegionalOptions {
   readonly region: string;
   readonly dbSubnetGroupName?: string;
-  readonly dbClusterpPG?: string;
+  readonly dbParameterGroup?: string;
   readonly securityGroupId?: string;
 }
 
@@ -769,7 +769,7 @@ export class GlobalAuroraRDSMaster extends cdk.Construct {
         secondRDSClusterArn,
         seconddbInstanceIdentifier,
         securityGroup: options.securityGroupId,
-        dbParameterGroup: options.dbClusterpPG,
+        dbParameterGroup: options.dbParameterGroup,
       },
     });
     CRSecondRDSProvider.node.addDependency(this.crGlobalRDSProvider);

--- a/src/index.ts
+++ b/src/index.ts
@@ -518,6 +518,7 @@ export interface GlobalAuroraRDSMasterProps {
 export interface RegionalOptions {
   readonly region: string;
   readonly dbSubnetGroupName?: string;
+  readonly dbClusterpPG?: string;
   readonly securityGroupId?: string;
 }
 
@@ -768,17 +769,18 @@ export class GlobalAuroraRDSMaster extends cdk.Construct {
         secondRDSClusterArn,
         seconddbInstanceIdentifier,
         securityGroup: options.securityGroupId,
+        dbParameterGroup: options.dbClusterpPG,
       },
     });
     CRSecondRDSProvider.node.addDependency(this.crGlobalRDSProvider);
     onEvent.role?.addToPrincipalPolicy(CustomResourcePolicy);
 
     new cdk.CfnOutput(scope, 'secondRDSClusterArn', {
-      value: secondRDSClusterArn
+      value: secondRDSClusterArn,
     });
 
     new cdk.CfnOutput(scope, 'seconddbInstanceIdentifier', {
-      value: seconddbInstanceIdentifier
+      value: seconddbInstanceIdentifier,
     });
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -841,17 +841,7 @@ export class GlobalAuroraRDSSlaveInfra extends cdk.Construct {
     });
 
     const DBsubnetType = props?.subnetType ?? ec2.SubnetType.PRIVATE;
-    if (DBsubnetType === ec2.SubnetType.PRIVATE) {
-      const PrivateSubnet = rdsVpcSecond.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE });
-      this.dbSubnetGroup = new rds.CfnDBSubnetGroup(this, 'Subnets', {
-        dbSubnetGroupName: `${stack.stackName.toLowerCase()}-privatesubnetgroup`,
-        dbSubnetGroupDescription: 'Private Subnets for database',
-        subnetIds: PrivateSubnet.subnetIds,
-      });
-
-      cdk.Tags.of(this.dbSubnetGroup).add('Name', 'PrivateDBSubnetGroup');
-      this.dbSubnetGroup.node.addDependency(rdsVpcSecond);
-    } else {
+    if (DBsubnetType === ec2.SubnetType.PUBLIC) {
       const PublicSubnet = rdsVpcSecond.selectSubnets({ subnetType: ec2.SubnetType.PUBLIC });
       this.dbSubnetGroup = new rds.CfnDBSubnetGroup(this, 'Subnets', {
         dbSubnetGroupName: `${stack.stackName.toLowerCase()}-publicsubnetgroup`,
@@ -860,6 +850,16 @@ export class GlobalAuroraRDSSlaveInfra extends cdk.Construct {
       });
 
       cdk.Tags.of(this.dbSubnetGroup).add('Name', 'PublicDBSubnetGroup');
+      this.dbSubnetGroup.node.addDependency(rdsVpcSecond);
+    } else {
+      const PrivateSubnet = rdsVpcSecond.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE });
+      this.dbSubnetGroup = new rds.CfnDBSubnetGroup(this, 'Subnets', {
+        dbSubnetGroupName: `${stack.stackName.toLowerCase()}-privatesubnetgroup`,
+        dbSubnetGroupDescription: 'Private Subnets for database',
+        subnetIds: PrivateSubnet.subnetIds,
+      });
+
+      cdk.Tags.of(this.dbSubnetGroup).add('Name', 'PrivateDBSubnetGroup');
       this.dbSubnetGroup.node.addDependency(rdsVpcSecond);
     }
     new cdk.CfnOutput(this, 'newDBSubnetGroup', {


### PR DESCRIPTION
Hi @neilkuan ,

I have raised this PR in hopes of adding extra needed feature to this useful utility you have here.

- added configurable VPC Security Group to secondary region cluster, up to now it would use default security group or error if default VPC is deleted (best practice)
- refactored CfnOutput for `secondRDSClusterArn`, `seconddbInstanceIdentifier` as you already create them in same file, no need to pass it in custom resource, then getAtt from the output. This also causes error as the onUpdate call to custom resource does not return the properties resulting in CloudFormation vendor error.
