### PR TITLE
Updated flexibility for multiple subnet options; Removed redundant code

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -877,27 +877,17 @@ export class GlobalAuroraRDSSlaveInfra extends Construct {
     });
 
     const DBsubnetType = props?.subnetType ?? ec2.SubnetType.PRIVATE_WITH_EGRESS;
-    if (DBsubnetType === ec2.SubnetType.PUBLIC) {
-      const PublicSubnet = rdsVpcSecond.selectSubnets({ subnetType: ec2.SubnetType.PUBLIC });
-      this.dbSubnetGroup = new rds.CfnDBSubnetGroup(this, 'Subnets', {
-        dbSubnetGroupName: `${stack.stackName.toLowerCase()}-publicsubnetgroup`,
-        dbSubnetGroupDescription: 'Public Subnets for database',
-        subnetIds: PublicSubnet.subnetIds,
-      });
+    const isPublic = DBsubnetType === ec2.SubnetType.PUBLIC;
+    const subnet = rdsVpcSecond.selectSubnets({ subnetType: DBsubnetType });
+    this.dbSubnetGroup = new rds.CfnDBSubnetGroup(this, 'Subnets', {
+      dbSubnetGroupName: `${stack.stackName.toLowerCase()}-${isPublic ? 'public' : 'private'}subnetgroup`,
+      dbSubnetGroupDescription: `${isPublic ? 'Public' : 'Private'} Subnets for database`,
+      subnetIds: subnet.subnetIds,
+    });
 
-      cdk.Tags.of(this.dbSubnetGroup).add('Name', 'PublicDBSubnetGroup');
-      this.dbSubnetGroup.node.addDependency(rdsVpcSecond);
-    } else {
-      const PrivateSubnet = rdsVpcSecond.selectSubnets({ subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS });
-      this.dbSubnetGroup = new rds.CfnDBSubnetGroup(this, 'Subnets', {
-        dbSubnetGroupName: `${stack.stackName.toLowerCase()}-privatesubnetgroup`,
-        dbSubnetGroupDescription: 'Private Subnets for database',
-        subnetIds: PrivateSubnet.subnetIds,
-      });
+    cdk.Tags.of(this.dbSubnetGroup).add('Name', `${isPublic ? 'Public' : 'Private'}DBSubnetGroup`);
+    this.dbSubnetGroup.node.addDependency(rdsVpcSecond);
 
-      cdk.Tags.of(this.dbSubnetGroup).add('Name', 'PrivateDBSubnetGroup');
-      this.dbSubnetGroup.node.addDependency(rdsVpcSecond);
-    }
     new cdk.CfnOutput(this, 'newDBSubnetGroup', {
       value: `${this.dbSubnetGroup.dbSubnetGroupName}`,
     });


### PR DESCRIPTION
### Updated
* SlaveInfra subnets are now selected by the one given (includes `PUBLIC`, `PRIVATE_WITH_EGRESS`, and `PRIVATE_ISOLATED`)
* Consolidated subnet logic into one block

I'm running into a python version issue on my machine when trying to run `yarn build` (everything else passes). Would you be able to run the build and confirm that it builds successfully? Thanks!